### PR TITLE
Update project.toml

### DIFF
--- a/project.toml
+++ b/project.toml
@@ -4,5 +4,5 @@ exclude = [
 ]
 
 [[build.env]]
-name = "BP_CARGO_EXCLUDE_FOLDERS"
+name = "BP_INCLUDE_FILES"
 value = "Rocket.toml"


### PR DESCRIPTION
The latest release of the Rust (and internally, Cargo CNB) changes `BP_CARGO_EXCLUDE_FOLDERS` to `BP_INCLUDE_FILES`.  The older env variable will still work for a while but will go away before GA of the Cargo CNB.